### PR TITLE
Fixing drive.auth() to deal with deprecation of sign_oauth

### DIFF
--- a/R/drive.auth.r
+++ b/R/drive.auth.r
@@ -42,13 +42,13 @@ drive.auth <- function(drive.app=NULL,drive.secret=NULL,drive.scope=NULL) {
     stop("Something went wrong, no credentials were returned")
   }
   
-  if("redirect_uri_mismatch" %in% cred) {
+  if("redirect_uri_mismatch" %in% ls(cred)) {
     stop("Please upgrade to the development version of httr. You can use the following to do so: `devtools::install_github(\"httr\")")
   }
   
-  google_sig <- sign_oauth2.0(cred$access_token)
+  # google_sig <- sign_oauth2.0(cred$access_token) # This is deprecated
   
-  options(drive.auth = google_sig)
+  options(drive.auth = cred)
   if(!is.null(getOption("drive.auth"))) {
     message("Authentication successful.")
   }

--- a/R/drive.file.r
+++ b/R/drive.file.r
@@ -16,7 +16,7 @@ drive.file <- function(title,download.type="txt") {
     file.listing$Link <- gsub("txt",download.type,file.listing$Link)
   }
 
-  response <- GET(file.listing$Link,getOption("drive.auth"))
+  response <- GET(file.listing$Link,config(token = getOption("drive.auth")))
   
   
   if(download.type == "html") { 

--- a/R/drive.list.r
+++ b/R/drive.list.r
@@ -20,7 +20,7 @@ drive.list <- function(search.term=NULL, show.titles=TRUE, download.type="txt") 
   
   raw.list <- GET(
     "https://www.googleapis.com/drive/v2/files?maxResults=100000", 
-    getOption("drive.auth")
+    config(token = getOption("drive.auth"))
   )
   
   parsed.list <- content(raw.list, as="parsed")


### PR DESCRIPTION
Authentication didn't work due to the deprecated sing_oauth.  This seems to fix it.
